### PR TITLE
Check if window.addEventListener is defined before invoking

### DIFF
--- a/extensions/netinfo/src/web/NetInfo.tsx
+++ b/extensions/netinfo/src/web/NetInfo.tsx
@@ -18,8 +18,8 @@ export class NetInfo extends Interfaces.NetInfo {
             this.connectivityChangedEvent.fire(navigator.onLine);
         };
 
-        // Avoid accessing window if it's not defined (for test environment).
-        if (typeof(window) !== 'undefined') {
+        // Avoid accessing window.addEventListener if it's not defined (for test and native environments).
+        if (typeof(window) !== 'undefined' && window.addEventListener) {
             window.addEventListener('online', onEventOccuredHandler);
             window.addEventListener('offline', onEventOccuredHandler);
         }


### PR DESCRIPTION
Otherwise, on native it fails with:

![image](https://github.com/user-attachments/assets/36230974-23e7-4e98-a83a-375ffc52c15f)
